### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin/
 packages/
 obj/
+.vs/
+*.user

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SampleCsChromium.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/SampleCsChromium.csproj
+++ b/SampleCsChromium.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\CefSharp.WinForms.57.0.0\build\CefSharp.WinForms.props" Condition="Exists('packages\CefSharp.WinForms.57.0.0\build\CefSharp.WinForms.props')" />
+  <Import Project="packages\CefSharp.Common.57.0.0\build\CefSharp.Common.props" Condition="Exists('packages\CefSharp.Common.57.0.0\build\CefSharp.Common.props')" />
   <Import Project="..\packages\CefSharp.WinForms.47.0.3\build\CefSharp.WinForms.props" Condition="Exists('..\packages\CefSharp.WinForms.47.0.3\build\CefSharp.WinForms.props')" />
   <Import Project="..\packages\CefSharp.Common.47.0.3\build\CefSharp.Common.props" Condition="Exists('..\packages\CefSharp.Common.47.0.3\build\CefSharp.Common.props')" />
-  <Import Project="packages\CefSharp.WinForms.47.0.3\build\CefSharp.WinForms.props" Condition="Exists('packages\CefSharp.WinForms.47.0.3\build\CefSharp.WinForms.props')" />
-  <Import Project="packages\CefSharp.Common.47.0.3\build\CefSharp.Common.props" Condition="Exists('packages\CefSharp.Common.47.0.3\build\CefSharp.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug32</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,11 +14,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SampleCsChromium</RootNamespace>
     <AssemblyName>SampleCsChromium</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,6 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>true</CodeAnalysisFailOnMissingRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -39,6 +41,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +52,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisFailOnMissingRules>true</CodeAnalysisFailOnMissingRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -59,6 +63,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -118,25 +123,22 @@ Erase "$(TargetPath)"</PostBuildEvent>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>
   </PropertyGroup>
-  <Import Project="packages\cef.redist.x86.3.2526.1362\build\cef.redist.x86.targets" Condition="Exists('packages\cef.redist.x86.3.2526.1362\build\cef.redist.x86.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\cef.redist.x86.3.2526.1362\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\cef.redist.x86.3.2526.1362\build\cef.redist.x86.targets'))" />
-    <Error Condition="!Exists('packages\cef.redist.x64.3.2526.1362\build\cef.redist.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\cef.redist.x64.3.2526.1362\build\cef.redist.x64.targets'))" />
-    <Error Condition="!Exists('packages\CefSharp.Common.47.0.3\build\CefSharp.Common.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\CefSharp.Common.47.0.3\build\CefSharp.Common.props'))" />
-    <Error Condition="!Exists('packages\CefSharp.Common.47.0.3\build\CefSharp.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\CefSharp.Common.47.0.3\build\CefSharp.Common.targets'))" />
-    <Error Condition="!Exists('packages\CefSharp.WinForms.47.0.3\build\CefSharp.WinForms.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\CefSharp.WinForms.47.0.3\build\CefSharp.WinForms.props'))" />
-    <Error Condition="!Exists('..\packages\cef.redist.x64.3.2526.1362\build\cef.redist.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x64.3.2526.1362\build\cef.redist.x64.targets'))" />
-    <Error Condition="!Exists('..\packages\cef.redist.x86.3.2526.1362\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\cef.redist.x86.3.2526.1362\build\cef.redist.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\CefSharp.Common.47.0.3\build\CefSharp.Common.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CefSharp.Common.47.0.3\build\CefSharp.Common.props'))" />
-    <Error Condition="!Exists('..\packages\CefSharp.Common.47.0.3\build\CefSharp.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CefSharp.Common.47.0.3\build\CefSharp.Common.targets'))" />
-    <Error Condition="!Exists('..\packages\CefSharp.WinForms.47.0.3\build\CefSharp.WinForms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CefSharp.WinForms.47.0.3\build\CefSharp.WinForms.props'))" />
-  </Target>
-  <Import Project="packages\cef.redist.x64.3.2526.1362\build\cef.redist.x64.targets" Condition="Exists('packages\cef.redist.x64.3.2526.1362\build\cef.redist.x64.targets')" />
-  <Import Project="packages\CefSharp.Common.47.0.3\build\CefSharp.Common.targets" Condition="Exists('packages\CefSharp.Common.47.0.3\build\CefSharp.Common.targets')" />
   <Import Project="..\packages\cef.redist.x64.3.2526.1362\build\cef.redist.x64.targets" Condition="Exists('..\packages\cef.redist.x64.3.2526.1362\build\cef.redist.x64.targets')" />
   <Import Project="..\packages\cef.redist.x86.3.2526.1362\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.2526.1362\build\cef.redist.x86.targets')" />
   <Import Project="..\packages\CefSharp.Common.47.0.3\build\CefSharp.Common.targets" Condition="Exists('..\packages\CefSharp.Common.47.0.3\build\CefSharp.Common.targets')" />
+  <Import Project="packages\cef.redist.x64.3.2987.1601\build\cef.redist.x64.targets" Condition="Exists('packages\cef.redist.x64.3.2987.1601\build\cef.redist.x64.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\cef.redist.x64.3.2987.1601\build\cef.redist.x64.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\cef.redist.x64.3.2987.1601\build\cef.redist.x64.targets'))" />
+    <Error Condition="!Exists('packages\cef.redist.x86.3.2987.1601\build\cef.redist.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\cef.redist.x86.3.2987.1601\build\cef.redist.x86.targets'))" />
+    <Error Condition="!Exists('packages\CefSharp.Common.57.0.0\build\CefSharp.Common.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\CefSharp.Common.57.0.0\build\CefSharp.Common.props'))" />
+    <Error Condition="!Exists('packages\CefSharp.Common.57.0.0\build\CefSharp.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\CefSharp.Common.57.0.0\build\CefSharp.Common.targets'))" />
+    <Error Condition="!Exists('packages\CefSharp.WinForms.57.0.0\build\CefSharp.WinForms.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\CefSharp.WinForms.57.0.0\build\CefSharp.WinForms.props'))" />
+    <Error Condition="!Exists('packages\CefSharp.WinForms.57.0.0\build\CefSharp.WinForms.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\CefSharp.WinForms.57.0.0\build\CefSharp.WinForms.targets'))" />
+  </Target>
+  <Import Project="packages\cef.redist.x86.3.2987.1601\build\cef.redist.x86.targets" Condition="Exists('packages\cef.redist.x86.3.2987.1601\build\cef.redist.x86.targets')" />
+  <Import Project="packages\CefSharp.Common.57.0.0\build\CefSharp.Common.targets" Condition="Exists('packages\CefSharp.Common.57.0.0\build\CefSharp.Common.targets')" />
+  <Import Project="packages\CefSharp.WinForms.57.0.0\build\CefSharp.WinForms.targets" Condition="Exists('packages\CefSharp.WinForms.57.0.0\build\CefSharp.WinForms.targets')" />
 </Project>

--- a/SampleCsChromium.sln
+++ b/SampleCsChromium.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleCsChromium", "SampleCsChromium.csproj", "{121C58CE-A403-472F-8B6E-F26DB8D504BC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{121C58CE-A403-472F-8B6E-F26DB8D504BC}.Debug|x64.ActiveCfg = Debug|x64
+		{121C58CE-A403-472F-8B6E-F26DB8D504BC}.Debug|x64.Build.0 = Debug|x64
+		{121C58CE-A403-472F-8B6E-F26DB8D504BC}.Debug|x86.ActiveCfg = Debug|x86
+		{121C58CE-A403-472F-8B6E-F26DB8D504BC}.Debug|x86.Build.0 = Debug|x86
+		{121C58CE-A403-472F-8B6E-F26DB8D504BC}.Release|x64.ActiveCfg = Release|x64
+		{121C58CE-A403-472F-8B6E-F26DB8D504BC}.Release|x64.Build.0 = Release|x64
+		{121C58CE-A403-472F-8B6E-F26DB8D504BC}.Release|x86.ActiveCfg = Release|x86
+		{121C58CE-A403-472F-8B6E-F26DB8D504BC}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5D7D4583-2CC8-462F-82AD-2BEE91C6C4B9}
+	EndGlobalSection
+EndGlobal

--- a/SampleCsChromiumPanelControl.cs
+++ b/SampleCsChromiumPanelControl.cs
@@ -7,58 +7,77 @@ using System.IO;
 
 namespace SampleCsChromium
 {
-  [System.Runtime.InteropServices.Guid("A687BDD9-F74C-4BB2-88E0-E2AEC95A9FCE")]
-  public partial class SampleCsChromiumPanelControl : UserControl
-  {
-    private ChromiumWebBrowser m_browser;
-
-    /// <summary>
-    /// Returns the ID of this panel.
-    /// </summary>
-    public static Guid PanelId
+    [System.Runtime.InteropServices.Guid("A687BDD9-F74C-4BB2-88E0-E2AEC95A9FCE")]
+    public partial class SampleCsChromiumPanelControl : UserControl
     {
-      get
-      {
-        return typeof(SampleCsChromiumPanelControl).GUID;
-      }
+        private ChromiumWebBrowser m_browser;
+
+        /// <summary>
+        /// Returns the ID of this panel.
+        /// </summary>
+        public static Guid PanelId
+        {
+            get
+            {
+                return typeof(SampleCsChromiumPanelControl).GUID;
+            }
+        }
+
+        public SampleCsChromiumPanelControl()
+        {
+            InitializeComponent();
+            InitializeBrowser();
+            SampleCsChromiumPlugIn.Instance.UserControl = this;
+            this.Disposed += new EventHandler(OnDisposed);
+            Rhino.RhinoApp.Closing += RhinoApp_Closing;
+
+        }
+
+        private void InitializeBrowser()
+        {
+            Cef.EnableHighDPISupport();
+
+            string assemblyLocation = Assembly.GetExecutingAssembly().Location;
+            string assemblyPath = Path.GetDirectoryName(assemblyLocation);
+            string pathSubprocess = Path.Combine(assemblyPath, "CefSharp.BrowserSubprocess.exe");
+
+            var settings = new CefSettings();
+            settings.BrowserSubprocessPath = pathSubprocess;
+
+            //the following setting is added to support Rhino 5.
+            // With versions of CefSharp > 47.0.3, the content is rendered on 1/4 of the control area.
+            // This setting fixes this, but at the consequence of disabling WebGL. 
+            // If you need WebGL in CefSharp and are targeting Rhino 5, use CefSharp 47.0.3 without this setting.
+            settings.DisableGpuAcceleration();
+
+            Cef.Initialize(settings);
+
+            m_browser = new ChromiumWebBrowser("http://www.rhino3d.com/");
+            Controls.Add(m_browser);
+            m_browser.Dock = DockStyle.Fill;
+            m_browser.Enabled = true;
+            m_browser.Show();
+        }
+
+        /// <summary>
+        /// Occurs when the component is disposed by a call to the
+        /// System.ComponentModel.Component.Dispose() method.
+        /// </summary>
+        private void OnDisposed(object sender, EventArgs e)
+        {
+            m_browser.Dispose();
+            Cef.Shutdown();
+            SampleCsChromiumPlugIn.Instance.UserControl = null;
+        }
+
+        /// <summary>
+        /// Disposes of the browser when Rhino closes.
+        /// </summary>
+        private void RhinoApp_Closing(object sender, EventArgs e)
+        {
+            m_browser.Dispose();
+            Cef.Shutdown();
+            SampleCsChromiumPlugIn.Instance.UserControl = null;
+        }
     }
-
-    public SampleCsChromiumPanelControl()
-    {
-      InitializeComponent();
-      InitializeBrowser();
-      SampleCsChromiumPlugIn.Instance.UserControl = this;
-      this.Disposed += new EventHandler(OnDisposed);
-    }
-
-    private void InitializeBrowser()
-    {
-      Cef.EnableHighDPISupport();
-
-      string assemblyLocation = Assembly.GetExecutingAssembly().Location;
-      string assemblyPath = Path.GetDirectoryName(assemblyLocation);
-      string pathSubprocess = Path.Combine(assemblyPath, "CefSharp.BrowserSubprocess.exe");
-
-      var settings = new CefSettings();
-      settings.BrowserSubprocessPath = pathSubprocess;
-      Cef.Initialize(settings);
-
-      m_browser = new ChromiumWebBrowser("http://www.rhino3d.com/");
-      Controls.Add(m_browser);
-      m_browser.Dock = DockStyle.Fill;
-      m_browser.Enabled = true;
-      m_browser.Show();
-    }
-
-    /// <summary>
-    /// Occurs when the component is disposed by a call to the
-    /// System.ComponentModel.Component.Dispose() method.
-    /// </summary>
-    private void OnDisposed(object sender, EventArgs e)
-    {
-      m_browser.Dispose();
-      Cef.Shutdown();
-      SampleCsChromiumPlugIn.Instance.UserControl = null;
-    }
-  }
 }

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cef.redist.x64" version="3.2526.1362" targetFramework="net40" />
-  <package id="cef.redist.x86" version="3.2526.1362" targetFramework="net40" />
-  <package id="CefSharp.Common" version="47.0.3" targetFramework="net40" />
-  <package id="CefSharp.WinForms" version="47.0.3" targetFramework="net40" />
+  <package id="cef.redist.x64" version="3.2987.1601" targetFramework="net40" />
+  <package id="cef.redist.x86" version="3.2987.1601" targetFramework="net40" />
+  <package id="CefSharp.Common" version="57.0.0" targetFramework="net40" />
+  <package id="CefSharp.WinForms" version="57.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
- Fixes #1  - Rhino 5 only renders in 1/4 of the control area when using CefSharp versions > 47.0.3. Disabling GPU acceleration fixes this at the cost of disabling WebGL. Updated to latest stable CefSharp, and updated to .Net Framework 4.5.2 to support latest CefSharp.
- Fixes #4 - Application would hang because OnClosing never hit, thus CefSharp was never shutdown and a subprocess.exe would continue running. Added a handler to fire when Rhino is closing to shut everything down.